### PR TITLE
Integrate `Testcontainers` for `PostgreSQL` and `Kafka` in Integratio…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,8 @@ permissions:
   contents: read
 
 jobs:
-  # ---------- tests (auto on PR/push; auto on manual if any later stage requested) ----------
-  tests:
+  # ---------- unit tests (auto on PR/push; auto on manual if any later stage requested) ----------
+  unit_tests:
     if: >
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master')) ||
@@ -66,17 +66,40 @@ jobs:
           java-version: '21'
           cache: 'maven'
 
-      - name: Run tests
+      - name: Run UNIT tests (@Tag("unit"))
         run: |
           set -Eeuo pipefail
-          mvn -B test
+          mvn -B test -Dgroups='unit'
+
+  # ---------- integration tests (auto on PR/push; auto on manual if any later stage requested) ----------
+  integration_tests:
+    if: >
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master')) ||
+      (github.event_name == 'workflow_dispatch' &&
+      (inputs.run_tests || inputs.run_build_jar || inputs.run_build_docker || inputs.run_deploy))
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up JDK 21 (Temurin) with Maven cache
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: 'maven'
+      - name: Run INTEGRATION tests (@Tag("integration"))
+        run: |
+          set -Eeuo pipefail
+          mvn -B test -Dgroups='integration'
 
   # ---------- build jar (manual; auto-triggered if docker/deploy requested) ----------
   build_jar:
     if: >
       github.event_name == 'workflow_dispatch' &&
       (inputs.run_build_jar || inputs.run_build_docker || inputs.run_deploy)
-    needs: [ tests ]
+    needs: [ unit_tests, integration_tests ]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Run tests
         run: |
           set -Eeuo pipefail
-          mvn -B -Dgroups=!integration -Dspring.profiles.active=test test
+          mvn -B test
 
   # ---------- build jar (manual; auto-triggered if docker/deploy requested) ----------
   build_jar:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ their content, and receive notifications about domain events.
 * **MapStruct** 1.6.3 (+ annotation processor)
 * **Spring Kafka**, **Spring Cloud Consul Discovery**, **Actuator**
 * **OpenAPI/Swagger** via `springdoc-openapi-starter-webmvc-ui` 2.8.9
-* Tests: **JUnit 5**, **Mockito**, **spring-security-test** (Surefire with `-XX:+EnableDynamicAgentLoading`)
+* Testing: **JUnit 5**, **Mockito**, **spring-security-test** (Surefire with `-XX:+EnableDynamicAgentLoading`)
+* **Testcontainers:** PostgreSQL + Kafka
 
 All versions are aligned with this service’s `pom.xml`.
 
@@ -150,12 +151,16 @@ docker run -d --restart unless-stopped \
 
 ```bash
 # run unit tests
-mvn test -Dgroups='!integration'
+mvn test -Dgroups='unit'
 ```
 
 ```bash
-# integration test requires postgres and kafka
-docker compose up -d
+# integration test
+mvn test -Dgroups='integration'
+```
+
+```bash
+# all test
 mvn test
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,26 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -45,16 +45,8 @@ springdoc.api-docs.path=/v3/api-docs
 # Kafka
 kafka.enabled=true
 spring.kafka.bootstrap-servers=kafka:9092
-spring.kafka.consumer.group-id=iam_service
 
 additional.kafka.topic.iam.service.logs=iam_topic_for_demo
-
-spring.kafka.listener.ack-mode=manual
-
-spring.kafka.consumer.enable-auto-commit=false
-spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
-spring.kafka.consumer.value-deserializer=org.apache.kafka.common.serialization.StringDeserializer
-spring.kafka.consumer.auto-offset-reset=earliest
 
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.producer.value-serializer=org.apache.kafka.common.serialization.StringSerializer

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -26,13 +26,6 @@ spring.flyway.locations=classpath:db/migration
 kafka.enabled=true
 spring.kafka.bootstrap-servers=${KAFKA_HOST}:9092
 
-spring.kafka.listener.ack-mode=manual
-spring.kafka.consumer.group-id=iam_service
-spring.kafka.consumer.enable-auto-commit=false
-spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
-spring.kafka.consumer.value-deserializer=org.apache.kafka.common.serialization.StringDeserializer
-spring.kafka.consumer.auto-offset-reset=earliest
-
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.producer.value-serializer=org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.producer.compression-type=lz4

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -32,6 +32,9 @@ spring.kafka.producer.compression-type=lz4
 spring.kafka.producer.batch-size=50000
 spring.kafka.retry.topic.enabled=true
 
+# Consul
+spring.cloud.consul.enabled=false
+
 # Logging Level
 logging.level.com.post.hub.iamservice=WARN
 logging.level.org.springframework.web=WARN

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -3,26 +3,10 @@ server.servlet.context-path=/
 
 server.port=0
 
-# JWT
-jwt.secret=0t+qP2zORoeMjjNYFKyRRO+h6v1kszGwrRXDBu+2JdYpec9I3ZBY/iAdUeeCgGpAw1FWTkG6pa9581nvtIZt6w==
-jwt.lifetime=3600000
-jwt.expiration=103600000
-
-# PostgreSQL
-spring.datasource.url=jdbc:postgresql://localhost:5432/post_hub_local
-spring.datasource.username=postgres
-spring.datasource.password=postgres
-spring.datasource.driver-class-name=org.postgresql.Driver
-
 # JPA
 spring.jpa.properties.hibernate.default_schema=v1_iam_service
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.open-in-view=false
-
-# Flyway
-spring.flyway.enabled=true
-spring.flyway.locations=classpath:db/migration
-spring.flyway.schemas=v1_iam_service
 
 # Endpoints
 endpoint.posts=/posts
@@ -37,25 +21,10 @@ endpoint.comments=/comments
 endpoint.logout=/logout
 endpoint.password.reset=/password/reset
 
-# Swagger
-swagger.servers.first=http://localhost:8100
-swagger.servers.second=http://localhost:8189
-springdoc.swagger-ui.path=/swagger-ui.html
-springdoc.api-docs.path=/v3/api-docs
-
 # Kafka
 kafka.enabled=true
-spring.kafka.bootstrap-servers=localhost:9092
-spring.kafka.consumer.group-id=iam_service
-
+spring.kafka.admin.auto-create=true
 additional.kafka.topic.iam.service.logs=iam_topic_for_test
-
-spring.kafka.listener.ack-mode=manual
-
-spring.kafka.consumer.enable-auto-commit=false
-spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
-spring.kafka.consumer.value-deserializer=org.apache.kafka.common.serialization.StringDeserializer
-spring.kafka.consumer.auto-offset-reset=earliest
 
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.producer.value-serializer=org.apache.kafka.common.serialization.StringSerializer
@@ -68,3 +37,4 @@ logging.level.com.post.hub.iamservice=WARN
 logging.level.org.springframework.web=WARN
 logging.level.org.flywaydb=WARN
 logging.level.org.springframework.cloud.consul=WARN
+logging.level.com.post.hub.iamservice.advice.CommonControllerAdvice=OFF

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -45,16 +45,8 @@ springdoc.api-docs.path=/v3/api-docs
 # Kafka
 kafka.enabled=true
 spring.kafka.bootstrap-servers=localhost:9092
-spring.kafka.consumer.group-id=iam_service
 
 additional.kafka.topic.iam.service.logs=iam_topic_for_demo
-
-spring.kafka.listener.ack-mode=manual
-
-spring.kafka.consumer.enable-auto-commit=false
-spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
-spring.kafka.consumer.value-deserializer=org.apache.kafka.common.serialization.StringDeserializer
-spring.kafka.consumer.auto-offset-reset=earliest
 
 spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
 spring.kafka.producer.value-serializer=org.apache.kafka.common.serialization.StringSerializer

--- a/src/test/java/com/post/hub/iamservice/KafkaTestTopicsConfig.java
+++ b/src/test/java/com/post/hub/iamservice/KafkaTestTopicsConfig.java
@@ -1,0 +1,20 @@
+package com.post.hub.iamservice;// например рядом с твоим BaseIntegrationTest
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.test.context.ActiveProfiles;
+
+@Configuration
+@ActiveProfiles("test")
+public class KafkaTestTopicsConfig {
+
+    @Bean
+    public NewTopic iamLogsTopic() {
+        return TopicBuilder.name("iam_topic_for_test")
+                .partitions(1)
+                .replicas(1)
+                .build();
+    }
+}

--- a/src/test/java/com/post/hub/iamservice/integration/BaseIntegrationTest.java
+++ b/src/test/java/com/post/hub/iamservice/integration/BaseIntegrationTest.java
@@ -1,0 +1,39 @@
+package com.post.hub.iamservice.integration;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Import(BaseIntegrationTest.Containers.class)
+public abstract class BaseIntegrationTest {
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class Containers {
+
+        @Bean
+        @ServiceConnection
+        PostgreSQLContainer<?> postgres() {
+            try (PostgreSQLContainer<?> container = new PostgreSQLContainer<>("postgres:17.6")) {
+                return container.withDatabaseName("post_hub_test")
+                        .withUsername("test_user")
+                        .withPassword("test_password");
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to start PostgreSQLContainer", e);
+            }
+        }
+
+        @Bean
+        @ServiceConnection
+        KafkaContainer kafka() {
+            return new KafkaContainer(DockerImageName.parse("apache/kafka:4.1.0"));
+        }
+    }
+}

--- a/src/test/java/com/post/hub/iamservice/integration/KafkaTestTopicsConfig.java
+++ b/src/test/java/com/post/hub/iamservice/integration/KafkaTestTopicsConfig.java
@@ -1,4 +1,4 @@
-package com.post.hub.iamservice;// например рядом с твоим BaseIntegrationTest
+package com.post.hub.iamservice.integration;// например рядом с твоим BaseIntegrationTest
 
 import org.apache.kafka.clients.admin.NewTopic;
 import org.springframework.context.annotation.Bean;

--- a/src/test/java/com/post/hub/iamservice/integration/controller/AuthControllerTest.java
+++ b/src/test/java/com/post/hub/iamservice/integration/controller/AuthControllerTest.java
@@ -1,21 +1,17 @@
 package com.post.hub.iamservice.integration.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.post.hub.iamservice.IamServiceApplication;
+import com.post.hub.iamservice.integration.BaseIntegrationTest;
 import com.post.hub.iamservice.model.request.user.LoginRequest;
 import com.post.hub.iamservice.model.request.user.RegistrationUserRequest;
 import com.post.hub.iamservice.model.response.IamResponse;
 import lombok.Setter;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -25,12 +21,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.io.IOException;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@SpringBootTest(classes = {IamServiceApplication.class})
 @AutoConfigureMockMvc
-@ExtendWith({MockitoExtension.class, SpringExtension.class})
+@ActiveProfiles("test")
 @Tag("integration")
-class AuthControllerTest {
+class AuthControllerTest extends BaseIntegrationTest {
 
     @Autowired
     @Setter

--- a/src/test/java/com/post/hub/iamservice/integration/controller/CommentControllerTest.java
+++ b/src/test/java/com/post/hub/iamservice/integration/controller/CommentControllerTest.java
@@ -3,7 +3,7 @@ package com.post.hub.iamservice.integration.controller;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.post.hub.iamservice.IamServiceApplication;
+import com.post.hub.iamservice.integration.BaseIntegrationTest;
 import com.post.hub.iamservice.model.dto.comment.CommentDTO;
 import com.post.hub.iamservice.model.dto.comment.CommentSearchDTO;
 import com.post.hub.iamservice.model.entities.User;
@@ -18,16 +18,11 @@ import com.post.hub.iamservice.security.JwtTokenProvider;
 import lombok.Setter;
 import org.hibernate.Hibernate;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -37,13 +32,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.io.IOException;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@SpringBootTest(classes = IamServiceApplication.class)
 @AutoConfigureMockMvc
-@ExtendWith({MockitoExtension.class, SpringExtension.class})
-@TestPropertySource(properties = {"logging.level.com.post.hub.iamservice.advice.CommonControllerAdvice=OFF"})
+@ActiveProfiles("test")
 @Tag("integration")
-public class CommentControllerTest {
+public class CommentControllerTest extends BaseIntegrationTest {
 
     private static final int EXISTING_COMMENT_ID = 1;
     private static final int MISSING_COMMENT_ID = 9_999_999;

--- a/src/test/java/com/post/hub/iamservice/integration/controller/PostControllerTest.java
+++ b/src/test/java/com/post/hub/iamservice/integration/controller/PostControllerTest.java
@@ -3,7 +3,7 @@ package com.post.hub.iamservice.integration.controller;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.post.hub.iamservice.IamServiceApplication;
+import com.post.hub.iamservice.integration.BaseIntegrationTest;
 import com.post.hub.iamservice.model.dto.post.PostDTO;
 import com.post.hub.iamservice.model.dto.post.PostSearchDTO;
 import com.post.hub.iamservice.model.entities.User;
@@ -18,16 +18,11 @@ import com.post.hub.iamservice.security.JwtTokenProvider;
 import lombok.Setter;
 import org.hibernate.Hibernate;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -37,13 +32,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.io.IOException;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@SpringBootTest(classes = IamServiceApplication.class)
 @AutoConfigureMockMvc
-@ExtendWith({MockitoExtension.class, SpringExtension.class})
-@TestPropertySource(properties = {"logging.level.com.post.hub.iamservice.advice.CommonControllerAdvice=OFF"})
+@ActiveProfiles("test")
 @Tag("integration")
-public class PostControllerTest {
+public class PostControllerTest extends BaseIntegrationTest {
 
     private static final int EXISTING_POST_ID = 1;
     private static final int MISSING_POST_ID = 9_999_999;

--- a/src/test/java/com/post/hub/iamservice/integration/controller/UserControllerTest.java
+++ b/src/test/java/com/post/hub/iamservice/integration/controller/UserControllerTest.java
@@ -3,7 +3,7 @@ package com.post.hub.iamservice.integration.controller;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.post.hub.iamservice.IamServiceApplication;
+import com.post.hub.iamservice.integration.BaseIntegrationTest;
 import com.post.hub.iamservice.model.dto.user.UserDTO;
 import com.post.hub.iamservice.model.entities.User;
 import com.post.hub.iamservice.model.exception.InvalidDataException;
@@ -15,15 +15,11 @@ import com.post.hub.iamservice.security.JwtTokenProvider;
 import lombok.Setter;
 import org.hibernate.Hibernate;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -33,12 +29,10 @@ import org.springframework.transaction.annotation.Transactional;
 import java.io.IOException;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@SpringBootTest(classes = IamServiceApplication.class)
 @AutoConfigureMockMvc
-@ExtendWith({MockitoExtension.class, SpringExtension.class})
+@ActiveProfiles("test")
 @Tag("integration")
-public class UserControllerTest {
+public class UserControllerTest extends BaseIntegrationTest {
 
     @Autowired
     @Setter

--- a/src/test/java/com/post/hub/iamservice/unit/service/AuthServiceTest.java
+++ b/src/test/java/com/post/hub/iamservice/unit/service/AuthServiceTest.java
@@ -1,4 +1,4 @@
-package com.post.hub.iamservice.service;
+package com.post.hub.iamservice.unit.service;
 
 import com.post.hub.iamservice.mapper.UserMapper;
 import com.post.hub.iamservice.model.dto.user.UserProfileDTO;
@@ -17,11 +17,13 @@ import com.post.hub.iamservice.repository.RoleRepository;
 import com.post.hub.iamservice.repository.UserRepository;
 import com.post.hub.iamservice.security.JwtTokenProvider;
 import com.post.hub.iamservice.security.validation.AccessValidator;
+import com.post.hub.iamservice.service.RefreshTokenService;
 import com.post.hub.iamservice.service.impl.AuthServiceImpl;
 import com.post.hub.iamservice.service.model.IamServiceUserRole;
 import com.post.hub.iamservice.utils.ApiUtils;
 import com.post.hub.iamservice.utils.PasswordUtils;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,6 +47,7 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
+@Tag("unit")
 public class AuthServiceTest {
 
     @Mock

--- a/src/test/java/com/post/hub/iamservice/unit/service/CommentServiceTest.java
+++ b/src/test/java/com/post/hub/iamservice/unit/service/CommentServiceTest.java
@@ -1,4 +1,4 @@
-package com.post.hub.iamservice.service;
+package com.post.hub.iamservice.unit.service;
 
 import com.post.hub.iamservice.kafka.service.KafkaMessageService;
 import com.post.hub.iamservice.mapper.CommentMapper;
@@ -20,6 +20,7 @@ import com.post.hub.iamservice.security.validation.AccessValidator;
 import com.post.hub.iamservice.service.impl.CommentServiceImpl;
 import com.post.hub.iamservice.utils.ApiUtils;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,6 +45,7 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
+@Tag("unit")
 public class CommentServiceTest {
 
     @Mock

--- a/src/test/java/com/post/hub/iamservice/unit/service/PostServiceTest.java
+++ b/src/test/java/com/post/hub/iamservice/unit/service/PostServiceTest.java
@@ -1,4 +1,4 @@
-package com.post.hub.iamservice.service;
+package com.post.hub.iamservice.unit.service;
 
 import com.post.hub.iamservice.kafka.service.KafkaMessageService;
 import com.post.hub.iamservice.mapper.PostMapper;
@@ -19,6 +19,7 @@ import com.post.hub.iamservice.security.validation.AccessValidator;
 import com.post.hub.iamservice.service.impl.PostServiceImpl;
 import com.post.hub.iamservice.utils.ApiUtils;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -43,6 +44,7 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
+@Tag("unit")
 class PostServiceTest {
 
     @Mock

--- a/src/test/java/com/post/hub/iamservice/unit/service/UserServiceTest.java
+++ b/src/test/java/com/post/hub/iamservice/unit/service/UserServiceTest.java
@@ -1,4 +1,4 @@
-package com.post.hub.iamservice.service;
+package com.post.hub.iamservice.unit.service;
 
 import com.post.hub.iamservice.kafka.service.KafkaMessageService;
 import com.post.hub.iamservice.mapper.UserMapper;
@@ -19,6 +19,7 @@ import com.post.hub.iamservice.security.validation.AccessValidator;
 import com.post.hub.iamservice.service.impl.UserServiceImpl;
 import com.post.hub.iamservice.service.model.IamServiceUserRole;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,6 +48,7 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
+@Tag("unit")
 class UserServiceTest {
 
     @Mock

--- a/src/test/java/com/post/hub/iamservice/unit/utils/PasswordUtilsTest.java
+++ b/src/test/java/com/post/hub/iamservice/unit/utils/PasswordUtilsTest.java
@@ -1,7 +1,9 @@
-package com.post.hub.iamservice.utils;
+package com.post.hub.iamservice.unit.utils;
 
 import com.post.hub.iamservice.model.constants.ApiConstants;
+import com.post.hub.iamservice.utils.PasswordUtils;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -9,6 +11,7 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Tag("unit")
 class PasswordUtilsTest {
 
     @Test


### PR DESCRIPTION
### Summary
Added Testcontainers integration for PostgreSQL and Kafka.
All integration tests now run in isolated containers managed by Spring Boot (`@ServiceConnection`).

### Changes
- Added `BaseIntegrationTest` with containerized PostgreSQL and Kafka.
- Updated integration tests to use dynamic container URLs.
- Removed local DB/Kafka dependency from `application-test.properties`.

### Motivation
This removes dependency on local infrastructure and ensures reproducible test environments in CI/CD.

### Checklist
- [x] All tests pass locally  
- [x] Verified container startup in CI  
- [x] Removed obsolete config from test properties
- [x] Separate jobs for unit and integration tests