### PR TITLE
CI: Sanitize Docker image tag derived from branch name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,14 @@ jobs:
         id: meta
         run: |
           set -Eeuo pipefail
-          TAG="${{ github.ref_name }}-${{ github.run_id }}"
+          RAW="${GITHUB_REF_NAME}"
+          SAFE=$(echo "$RAW" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed -E 's#[^a-z0-9._-]+#-#g' \
+            | sed -E 's/^-+|-+$//g' \
+            | cut -c1-100)
+          SAFE="${SAFE:-branch}"
+          TAG="${SAFE}-${GITHUB_RUN_ID}"
           IMAGE="${CI_REGISTRY}/${CI_REGISTRY_USER}/${IMAGE_NAME}:${TAG}"
           echo "TAG=$TAG" >> "$GITHUB_ENV"
           echo "IMAGE=$IMAGE" >> "$GITHUB_ENV"
@@ -188,7 +195,14 @@ jobs:
       - name: Compute image tag (same formula as build)
         run: |
           set -Eeuo pipefail
-          TAG="${{ github.ref_name }}-${{ github.run_id }}"
+          RAW="${GITHUB_REF_NAME}"
+          SAFE=$(echo "$RAW" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed -E 's#[^a-z0-9._-]+#-#g' \
+            | sed -E 's/^-+|-+$//g' \
+            | cut -c1-100)
+          SAFE="${SAFE:-branch}"
+          TAG="${SAFE}-${GITHUB_RUN_ID}"
           IMAGE="${CI_REGISTRY}/${CI_REGISTRY_USER}/${IMAGE_NAME}:${TAG}"
           echo "IMAGE=$IMAGE" >> "$GITHUB_ENV"
           echo "Using image (deploy): $IMAGE"


### PR DESCRIPTION
**Context**  
Building and pushing Docker images failed with `invalid reference format` when the image tag was derived directly from the branch name (e.g., `feature/x/y` produces a tag with a slash).

**What changed**  
Sanitized the Docker tag computed from the branch/ref name in GitHub Actions:
- convert to lowercase
- replace any non `[a-z0-9_.-]` characters (including `/`) with `-`
- trim leading/trailing `-`
- limit the base to 100 characters
- use the same logic in both `build_docker` and `deploy` jobs

**Why**  
Docker tag constraints disallow `/` and other characters; using raw branch names can break builds. The sanitizer guarantees a valid tag and stable naming across services.
